### PR TITLE
Stringify file permission

### DIFF
--- a/coreos/user-data.yml.erb
+++ b/coreos/user-data.yml.erb
@@ -81,7 +81,7 @@ coreos:
     #     WantedBy=multi-user.target
 write_files:
   - path: /etc/ssh/sshd_config
-    permissions: 0600
+    permissions: "0600"
     owner: root:root
     content: |
       # Use most defaults for sshd configuration.


### PR DESCRIPTION
## WHY

When we try to use "replacing etcd discovery URL automatically" feature (written at [here](https://github.com/wantedly/boilerplate/blob/7802056cd400a46354a48d0cf0384b0995fa7709/coreos/config.rb#L15-L39)), CoreOS fails to load cloud-config.
The reason why is that `permissions: 0600` is parsed as **octal** number in Ruby. `0600` in octal is equal to `384` in decimal. This is invalid as file permission...
## WHAT

Declare file permission as String.
